### PR TITLE
Fix vertical centering for empty chat state

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -13,7 +13,7 @@ interface MessageListProps {
 export function MessageList({ messages, isLoading }: MessageListProps) {
   if (messages.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full px-4 text-center">
+      <div className="flex flex-col items-center justify-center min-h-[calc(100vh-200px)] px-4 text-center">
         <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-blue-50 mb-4 shadow-sm">
           <Bot className="h-7 w-7 text-blue-600" />
         </div>


### PR DESCRIPTION
## Summary
- Fixed vertical centering issue in the chat interface's empty state
- Updated MessageList component to use `min-h-[calc(100vh-200px)]` instead of `h-full`
- Ensures proper vertical centering within the scroll area context

## Test plan
- [ ] Start the development server with `npm run dev`
- [ ] Open the application in a browser
- [ ] Verify that the empty state content (bot icon and text) is properly centered vertically in the chat area
- [ ] Test with different viewport heights to ensure responsive behavior

🤖 Generated with [Claude Code](https://claude.ai/code)